### PR TITLE
Only selecting links having an href attribute

### DIFF
--- a/data/helpers/3-2016.json
+++ b/data/helpers/3-2016.json
@@ -45,14 +45,14 @@
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "a:has(img[ismap])",
+			"selector": "a[href]:has(img[ismap])",
 			"attributes": ["href"]
 		}
 	],
 	"1.2.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img)"
+			"selector": "img:not(a[href] img, button img)"
 		},
 		{
 			"helper": "showAttributes",
@@ -198,11 +198,11 @@
 	"1.3.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img)"
+			"selector": "img:not(a[href] img, button img)"
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "img:not(a img, button img)",
+			"selector": "img:not(a[href] img, button img)",
 			"attributes": ["alt", "title", "aria-label", "aria-labelledby"]
 		}
 	],
@@ -337,7 +337,7 @@
 	"1.3.13": [
 		{
 			"helper": "outline",
-			"selector": "a, img, map, svg, input[type=\"image\"][alt], object[type^=\"image\"], object[type^=\"image\"][aria-label], object[type^=\"image\"][aria-labelledby], embed[type^=\"image\"], embed[type^=\"image\"][title], embed[type^=\"image\"][aria-label], embed[type^=\"image\"][aria-labelledby]",
+			"selector": "a[href], img, map, svg, input[type=\"image\"][alt], object[type^=\"image\"], object[type^=\"image\"][aria-label], object[type^=\"image\"][aria-labelledby], embed[type^=\"image\"], embed[type^=\"image\"][title], embed[type^=\"image\"][aria-label], embed[type^=\"image\"][aria-labelledby]",
 			"showTag": true
 		},
 		{
@@ -1660,45 +1660,45 @@
 	"6.1.1": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"showTag": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		}
 	],
 	"6.1.2": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["title", "aria-label", "aria-labelledby"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
+			"selector": "a[href]:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1706,33 +1706,33 @@
 	"6.1.3": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["title", "aria-label", "aria-labelledby"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
+			"selector": "a[href]:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1819,44 +1819,44 @@
 	"6.3.1": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link']"
+			"selector": "a[href]:not([role]), [role='link']"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		}
 	],
 	"6.3.2": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap]"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap]"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
+			"selector": "a[href]:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1864,33 +1864,33 @@
 	"6.3.3": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap]"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap]"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
+			"selector": "a[href]:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1898,44 +1898,44 @@
 	"6.4.1": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link']"
+			"selector": "a[href]:not([role]), [role='link']"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		}
 	],
 	"6.4.2": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap]"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap]"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
+			"selector": "a[href]:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1943,33 +1943,33 @@
 	"6.4.3": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap]"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap]"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
+			"selector": "a[href]:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1977,16 +1977,16 @@
 	"6.5.1": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link']"
+			"selector": "a[href]:not([role]), [role='link']"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["aria-label"]
 		}
 	],
@@ -2251,7 +2251,7 @@
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "abbr, a",
+			"selector": "abbr, a[href]",
 			"attributes": ["title"]
 		}
 	],
@@ -2262,7 +2262,7 @@
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "abbr, a",
+			"selector": "abbr, a[href]",
 			"attributes": ["title"]
 		}
 	],
@@ -2360,7 +2360,7 @@
 	"10.7.3": [
 		{
 			"helper": "outline",
-			"selector": "a"
+			"selector": "a[href]"
 		}
 	],
 	"10.8.1": [],

--- a/data/helpers/3-2017.json
+++ b/data/helpers/3-2017.json
@@ -45,14 +45,14 @@
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "a:has(img[ismap])",
+			"selector": "a[href]:has(img[ismap])",
 			"attributes": ["href"]
 		}
 	],
 	"1.2.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img)"
+			"selector": "img:not(a[href] img, button img)"
 		},
 		{
 			"helper": "showAttributes",
@@ -216,11 +216,11 @@
 	"1.3.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img)"
+			"selector": "img:not(a[href] img, button img)"
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "img:not(a img, button img)",
+			"selector": "img:not(a[href] img, button img)",
 			"attributes": ["alt", "title", "aria-label", "aria-labelledby"]
 		}
 	],
@@ -355,7 +355,7 @@
 	"1.3.13": [
 		{
 			"helper": "outline",
-			"selector": "a, img, map, svg, input[type=\"image\"][alt], object[type^=\"image\"], object[type^=\"image\"][aria-label], object[type^=\"image\"][aria-labelledby], embed[type^=\"image\"], embed[type^=\"image\"][title], embed[type^=\"image\"][aria-label], embed[type^=\"image\"][aria-labelledby]",
+			"selector": "a[href], img, map, svg, input[type=\"image\"][alt], object[type^=\"image\"], object[type^=\"image\"][aria-label], object[type^=\"image\"][aria-labelledby], embed[type^=\"image\"], embed[type^=\"image\"][title], embed[type^=\"image\"][aria-label], embed[type^=\"image\"][aria-labelledby]",
 			"showTag": true
 		},
 		{
@@ -1687,45 +1687,45 @@
 	"6.1.1": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"showTag": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title", "aria-label", "aria-labelledby"]
 		}
 	],
 	"6.1.2": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["title", "aria-label", "aria-labelledby"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
+			"selector": "a[href]:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1733,33 +1733,33 @@
 	"6.1.3": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["title", "aria-label", "aria-labelledby"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
+			"selector": "a[href]:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1846,44 +1846,44 @@
 	"6.3.1": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link']"
+			"selector": "a[href]:not([role]), [role='link']"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		}
 	],
 	"6.3.2": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap]"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap]"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
+			"selector": "a[href]:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1891,33 +1891,33 @@
 	"6.3.3": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap]"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap]"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
+			"selector": "a[href]:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1925,44 +1925,44 @@
 	"6.4.1": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link']"
+			"selector": "a[href]:not([role]), [role='link']"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		}
 	],
 	"6.4.2": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap]"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap]"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
+			"selector": "a[href]:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1970,33 +1970,33 @@
 	"6.4.3": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap]"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap]"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
+			"selector": "a[href]:not([role]) canvas, a:not([role]) object, [role='link'] canvas, [role='link'] object",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -2004,21 +2004,21 @@
 	"6.5.1": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link']"
+			"selector": "a[href]:not([role]), [role='link']"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["aria-label", "aria-labelledby"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["aria-label"]
 		}
 	],
@@ -2284,7 +2284,7 @@
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "abbr, a",
+			"selector": "abbr, a[href]",
 			"attributes": ["title"]
 		}
 	],
@@ -2295,7 +2295,7 @@
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "abbr, a",
+			"selector": "abbr, a[href]",
 			"attributes": ["title"]
 		}
 	],
@@ -2393,7 +2393,7 @@
 	"10.7.3": [
 		{
 			"helper": "outline",
-			"selector": "a"
+			"selector": "a[href]"
 		}
 	],
 	"10.8.1": [],

--- a/data/helpers/4-2019.json
+++ b/data/helpers/4-2019.json
@@ -58,7 +58,7 @@
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "a:has(img[ismap])",
+			"selector": "a[href]:has(img[ismap])",
 			"attributes": ["href", "aria-hidden", "role"]
 		}
 	],
@@ -130,7 +130,7 @@
 	"1.2.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img)"
+			"selector": "img:not(a[href] img, button img)"
 		},
 		{
 			"helper": "showAttributes",
@@ -268,11 +268,11 @@
 	"1.3.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img), [role='img']:not(a [role='img'], button [role='img'])"
+			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img'])"
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "img:not(a img, button img), [role='img']:not(a [role='img'], button [role='img'])",
+			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img'])",
 			"attributes": ["alt", "title", "aria-label", "aria-labelledby"]
 		}
 	],
@@ -361,7 +361,7 @@
 	"1.3.9": [
 		{
 			"helper": "outline",
-			"selector": "a, img, map, svg, input[type=\"image\"][alt], object[type^=\"image\"], object[type^=\"image\"][aria-label], object[type^=\"image\"][aria-labelledby], embed[type^=\"image\"], embed[type^=\"image\"][title], embed[type^=\"image\"][aria-label], embed[type^=\"image\"][aria-labelledby]",
+			"selector": "a[href], img, map, svg, input[type=\"image\"][alt], object[type^=\"image\"], object[type^=\"image\"][aria-label], object[type^=\"image\"][aria-labelledby], embed[type^=\"image\"], embed[type^=\"image\"][title], embed[type^=\"image\"][aria-label], embed[type^=\"image\"][aria-labelledby]",
 			"showTag": true
 		},
 		{
@@ -1575,46 +1575,46 @@
 	"6.1.1": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"showTag": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title", "aria-label", "aria-labelledby"]
 		}
 	],
 	"6.1.2": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title", "aria-label", "aria-labelledby"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt", "title", "aria-label", "aria-labelledby"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc, text",
 			"attributes": [],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
+			"selector": "a[href]:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg, a:not([role]) canvas, [role='link'] canvas",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg, a:not([role]) canvas, [role='link'] canvas",
 			"attributes": ["aria-label", "aria-labelledby"],
 			"showContent": true
 		}
@@ -1622,34 +1622,34 @@
 	"6.1.3": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
+			"selector": "a[href]:not([role]), [role='link'], img[usemap], a:not([role]) canvas, [role='link'] canvas, a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed, a:not([role]) svg, [role='link'] svg"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["title", "aria-label", "aria-labelledby"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt", "title", "aria-label", "aria-labelledby"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"childrenSelector": "desc, text",
 			"attributes": ["x-link:title"],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
+			"selector": "a[href]:not([role]) object, [role='link'] object, a:not([role]) embed, [role='link'] embed",
 			"attributes": ["title", "aria-label", "aria-labelledby"],
 			"showContent": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg, a:not([role]) canvas, [role='link'] canvas",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg, a:not([role]) canvas, [role='link'] canvas",
 			"attributes": ["aria-label", "aria-labelledby", "x-link:title"],
 			"showContent": true
 		}
@@ -1657,17 +1657,17 @@
 	"6.1.4": [
 		{
 			"helper": "outline",
-			"selector": "svg:has(a)"
+			"selector": "svg:has(a[href])"
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg:has(a)",
+			"selector": "svg:has(a[href])",
 			"showContent": true
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "svg:has(a)",
-			"childrenSelector": "a",
+			"selector": "svg:has(a[href])",
+			"childrenSelector": "a[href]",
 			"attributes": [
 				"aria-label",
 				"aria-labelledby",
@@ -1680,21 +1680,21 @@
 	"6.2.1": [
 		{
 			"helper": "outline",
-			"selector": "a:not([role]), [role='link']"
+			"selector": "a[href]:not([role]), [role='link']"
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]), [role='link']",
+			"selector": "a[href]:not([role]), [role='link']",
 			"attributes": ["aria-label", "aria-labelledby"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) img, [role='link'] img, area[href]",
+			"selector": "a[href]:not([role]) img, [role='link'] img, area[href]",
 			"attributes": ["alt"]
 		},
 		{
 			"helper": "showElement",
-			"selector": "a:not([role]) svg, [role='link'] svg",
+			"selector": "a[href]:not([role]) svg, [role='link'] svg",
 			"attributes": ["aria-label"]
 		}
 	],

--- a/data/helpers/4-2021.json
+++ b/data/helpers/4-2021.json
@@ -2,12 +2,12 @@
 	"1.1.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
+			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
 			"showTag": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "img:not(a img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
+			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
 			"attributes": [
 				"aria-labelledby",
 				"aria-label",
@@ -59,25 +59,25 @@
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "a:has(img[ismap])",
+			"selector": "a[href]:has(img[ismap])",
 			"attributes": ["href", "aria-hidden", "role"]
 		}
 	],
 	"1.1.5": [
 		{
 			"helper": "outline",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"showTag": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"attributes": ["role", "aria-label", "aria-labelledby"],
 			"showMissingAttributes": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"attributes": ["aria-hidden", "role"]
 		}
 	],
@@ -150,7 +150,7 @@
 	"1.2.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img, figure img)"
+			"selector": "img:not(a[href] img, button img, figure img)"
 		},
 		{
 			"helper": "showAttributes",
@@ -213,23 +213,23 @@
 	"1.2.4": [
 		{
 			"helper": "outline",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"showTag": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"attributes": ["aria-hidden", "role"],
 			"showMissingAttributes": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"attributes": ["aria-label", "aria-labelledby", "title"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"childrenSelector": "title, desc, text",
 			"attributes": ["aria-label", "aria-labelledby", "title"],
 			"showMissingAttributes": true,
@@ -288,11 +288,11 @@
 	"1.3.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img), [role='img']:not(a [role='img'], button [role='img'])"
+			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img'])"
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "img:not(a img, button img), [role='img']:not(a [role='img'], button [role='img'])",
+			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img'])",
 			"attributes": ["alt", "title", "aria-label", "aria-labelledby"]
 		}
 	],
@@ -345,18 +345,18 @@
 	"1.3.6": [
 		{
 			"helper": "outline",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"showTag": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"attributes": ["aria-label", "aria-labelledby"],
 			"showMissingAttributes": true
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"childrenSelector": "title",
 			"attributes": [],
 			"showContent": true
@@ -388,12 +388,12 @@
 	"1.3.9": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img), map, svg:not(a svg, button svg), input[type=\"image\"][alt], object[type^=\"image\"], object[type^=\"image\"][aria-label], object[type^=\"image\"][aria-labelledby], embed[type^=\"image\"], embed[type^=\"image\"][title], embed[type^=\"image\"][aria-label], embed[type^=\"image\"][aria-labelledby]",
+			"selector": "img:not(a[href] img, button img), map, svg:not(a svg, button svg), input[type=\"image\"][alt], object[type^=\"image\"], object[type^=\"image\"][aria-label], object[type^=\"image\"][aria-labelledby], embed[type^=\"image\"], embed[type^=\"image\"][title], embed[type^=\"image\"][aria-label], embed[type^=\"image\"][aria-labelledby]",
 			"showTag": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "img:not(a img, button img), input[type=\"image\"][alt]",
+			"selector": "img:not(a[href] img, button img), input[type=\"image\"][alt]",
 			"attributes": ["alt", "title", "aria-label", "aria-labelledby"]
 		},
 		{
@@ -566,17 +566,17 @@
 	"1.6.6": [
 		{
 			"helper": "outline",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"showTag": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"childrenSelector": "title, desc",
 			"attributes": [],
 			"showContent": true
@@ -585,17 +585,17 @@
 	"1.6.7": [
 		{
 			"helper": "outline",
-			"selector": "svg:not(a svg, button svg):has(desc), svg:not(a svg, button svg)[aria-label]",
+			"selector": "svg:not(a[href] svg, button svg):has(desc), svg:not(a svg, button svg)[aria-label]",
 			"showTag": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "svg:not(a svg, button svg)[aria-label]",
+			"selector": "svg:not(a[href] svg, button svg)[aria-label]",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "svg:not(a svg, button svg):has(title)",
+			"selector": "svg:not(a[href] svg, button svg):has(title)",
 			"childrenSelector": "title",
 			"attributes": [],
 			"showContent": true
@@ -1662,17 +1662,17 @@
 	"6.1.4": [
 		{
 			"helper": "outline",
-			"selector": "svg:has(a)"
+			"selector": "svg:has(a[href])"
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg:has(a)",
+			"selector": "svg:has(a[href])",
 			"showContent": true
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "svg:has(a)",
-			"childrenSelector": "a",
+			"selector": "svg:has(a[href])",
+			"childrenSelector": "a[href]",
 			"attributes": [
 				"aria-label",
 				"aria-labelledby",

--- a/data/helpers/4-2023.json
+++ b/data/helpers/4-2023.json
@@ -2,12 +2,12 @@
 	"1.1.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
+			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
 			"showTag": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "img:not(a img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
+			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
 			"attributes": [
 				"aria-labelledby",
 				"aria-label",
@@ -59,26 +59,26 @@
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "a:has(img[ismap])",
+			"selector": "a[href]:has(img[ismap])",
 			"attributes": ["href", "aria-hidden", "role"]
 		}
 	],
 	"1.1.5": [
 		{
 			"helper": "outline",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"showTag": true
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"childrenSelector": "title",
 			"attributes": ["role", "aria-label", "aria-labelledby"],
 			"showMissingAttributes": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"attributes": ["aria-hidden", "role"]
 		}
 	],
@@ -151,7 +151,7 @@
 	"1.2.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img, figure img)"
+			"selector": "img:not(a[href] img, button img, figure img)"
 		},
 		{
 			"helper": "showAttributes",
@@ -214,23 +214,23 @@
 	"1.2.4": [
 		{
 			"helper": "outline",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"showTag": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"attributes": ["aria-hidden", "role"],
 			"showMissingAttributes": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"attributes": ["aria-label", "aria-labelledby", "title"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"childrenSelector": "title, desc, text",
 			"attributes": ["aria-label", "aria-labelledby", "title"],
 			"showMissingAttributes": true,
@@ -289,11 +289,11 @@
 	"1.3.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img), [role='img']:not(a [role='img'], button [role='img'])"
+			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img'])"
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "img:not(a img, button img), [role='img']:not(a [role='img'], button [role='img'])",
+			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img'])",
 			"attributes": ["alt", "title", "aria-label", "aria-labelledby"]
 		}
 	],
@@ -346,18 +346,18 @@
 	"1.3.6": [
 		{
 			"helper": "outline",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"showTag": true
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"attributes": ["aria-label", "aria-labelledby"],
 			"showMissingAttributes": true
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"childrenSelector": "title",
 			"attributes": [],
 			"showContent": true
@@ -389,12 +389,12 @@
 	"1.3.9": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a img, button img), map, svg:not(a svg, button svg), input[type=\"image\"][alt], object[type^=\"image\"], object[type^=\"image\"][aria-label], object[type^=\"image\"][aria-labelledby], embed[type^=\"image\"], embed[type^=\"image\"][title], embed[type^=\"image\"][aria-label], embed[type^=\"image\"][aria-labelledby]",
+			"selector": "img:not(a[href] img, button img), map, svg:not(a svg, button svg), input[type=\"image\"][alt], object[type^=\"image\"], object[type^=\"image\"][aria-label], object[type^=\"image\"][aria-labelledby], embed[type^=\"image\"], embed[type^=\"image\"][title], embed[type^=\"image\"][aria-label], embed[type^=\"image\"][aria-labelledby]",
 			"showTag": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "img:not(a img, button img), input[type=\"image\"][alt]",
+			"selector": "img:not(a[href] img, button img), input[type=\"image\"][alt]",
 			"attributes": ["alt", "title", "aria-label", "aria-labelledby"]
 		},
 		{
@@ -567,17 +567,17 @@
 	"1.6.6": [
 		{
 			"helper": "outline",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"showTag": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "svg:not(a svg, button svg)",
+			"selector": "svg:not(a[href] svg, button svg)",
 			"childrenSelector": "title, desc",
 			"attributes": [],
 			"showContent": true
@@ -586,17 +586,17 @@
 	"1.6.7": [
 		{
 			"helper": "outline",
-			"selector": "svg:not(a svg, button svg):has(desc), svg:not(a svg, button svg)[aria-label]",
+			"selector": "svg:not(a[href] svg, button svg):has(desc), svg:not(a svg, button svg)[aria-label]",
 			"showTag": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "svg:not(a svg, button svg)[aria-label]",
+			"selector": "svg:not(a[href] svg, button svg)[aria-label]",
 			"attributes": ["aria-label"]
 		},
 		{
 			"helper": "showChildElements",
-			"selector": "svg:not(a svg, button svg):has(title)",
+			"selector": "svg:not(a[href] svg, button svg):has(title)",
 			"childrenSelector": "title",
 			"attributes": [],
 			"showContent": true
@@ -1656,16 +1656,16 @@
 	"6.1.4": [
 		{
 			"helper": "outline",
-			"selector": "svg a"
+			"selector": "svg a[href]"
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg a",
+			"selector": "svg a[href]",
 			"showContent": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "svg a",
+			"selector": "svg a[href]",
 			"attributes": [
 				"aria-label",
 				"aria-labelledby",


### PR DESCRIPTION
Without this attribute, `a` tags are not considered links.
This fixes https://github.com/boscop-fr/assistant-rgaa/issues/55