### PR TITLE
Fixed extension permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,8 +18,7 @@
 		"default_panel": "pages/default-panel.html",
 		"open_at_install": false
 	},
-	"permissions": ["tabs", "storage", "scripting", "sidePanel"],
-	"host_permissions": ["<all_urls>"],
+	"permissions": ["activeTab", "storage", "scripting", "sidePanel"],
 	"background": {
 		"service_worker": "dist/background.js",
 		"scripts": ["dist/background.js"]


### PR DESCRIPTION
We're only using `activeTab` instead of `tabs` and `<all_urls>` host permission. This is enough to run the app, avoids some user-facing warnings, and speeds up the review process on the stores.