### PR TITLE
Ajout détecteur liens PDFs 13.3

### DIFF
--- a/data/helpers/4-2023.json
+++ b/data/helpers/4-2023.json
@@ -2700,6 +2700,17 @@
 			"attributes": ["http-equiv", "content"]
 		}
 	],
+	"13.3.1": [
+		{
+			"helper": "outline",
+			"selector": "a[href*='.pdf']",
+		},
+		{
+			"helper": "showAttributes",
+			"selector": "a[href*='.pdf']",
+			"attributes": ["href"]
+		}
+	],
 	"13.5.1": [
 		{
 			"helper": "showAttributes",
@@ -2720,5 +2731,5 @@
 			"selector": "video, img, svg, canvas, embed, object",
 			"showTag": true
 		}
-	]
+	],
 }


### PR DESCRIPTION
Afin de simplifier la recherche des liens PDFs dans la page, je propose ce sélecteur qui permet de les distinguer rapidement pour les télécharger et tester.

NB: le critère tient compte des autres documents bureautiques (.docx, .odt, etc...), il faudrait aussi ajouter des sélecteurs pour ces genres de fichiers