### PR TITLE
Fixed display of tag names when outlining

### DIFF
--- a/src/helpers/helpers/outline.tsx
+++ b/src/helpers/helpers/outline.tsx
@@ -29,6 +29,7 @@ export default createHelper({
 		return setHighlightOptionsEffect(selector, (highlights) => {
 			highlights.showOutline(true);
 			highlights.showTag(showTag);
+			highlights.showIfEmpty(true);
 		});
 	}
 });


### PR DESCRIPTION
We want the tag name to be shown even if the element has no relevant content.