### PR TITLE
Fixed tab reloading

### DIFF
--- a/src/common/utils/tabs.ts
+++ b/src/common/utils/tabs.ts
@@ -43,7 +43,7 @@ export const onTabMount = (id: number, callback: () => () => void) => {
 			return;
 		}
 
-		if (status === 'loading') {
+		if (status === 'loading' && !isLoading) {
 			isLoading = true;
 			cleanup();
 			return;

--- a/src/panel/index.tsx
+++ b/src/panel/index.tsx
@@ -43,6 +43,9 @@ const init = async () => {
 			.unwrap()
 			.then(() => {
 				store.dispatch(setLoading(false));
+			})
+			.catch((e) => {
+				console.error(e);
 			});
 
 		return () => {


### PR DESCRIPTION
The loading state is emitted multiple times when a tab is reloaded. We're preventing the cleanup logic to run multiple times as well. Also we're catching errors up top so the app doesn't crash if anything goes wrong.