### PR TITLE
Fine-tuning 1.1.1 test

### DIFF
--- a/data/helpers/4-2021.json
+++ b/data/helpers/4-2021.json
@@ -2,12 +2,12 @@
 	"1.1.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
+			"selector": "img:not(a[href] img, [role='link'] img, button img, [role='button'] img), [role='img']:not(a [role='img'], [role='link'] [role='img'], button [role='img'], [role='button'] [role='img'])",
 			"showTag": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
+			"selector": "img:not(a[href] img, [role='link'] img, button img, [role='button'] img), [role='img']:not(a [role='img'], [role='link'] [role='img'], button [role='img'], [role='button'] [role='img'])",
 			"attributes": [
 				"aria-labelledby",
 				"aria-label",

--- a/data/helpers/4-2023.json
+++ b/data/helpers/4-2023.json
@@ -2,12 +2,12 @@
 	"1.1.1": [
 		{
 			"helper": "outline",
-			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
+			"selector": "img:not(a[href] img, [role='link'] img, button img, [role='button'] img), [role='img']:not(a [role='img'], [role='link'] [role='img'], button [role='img'], [role='button'] [role='img'])",
 			"showTag": true
 		},
 		{
 			"helper": "showAttributes",
-			"selector": "img:not(a[href] img, button img), [role='img']:not(a [role='img'], button [role='img']), [role='link']",
+			"selector": "img:not(a[href] img, [role='link'] img, button img, [role='button'] img), [role='img']:not(a [role='img'], [role='link'] [role='img'], button [role='img'], [role='button'] [role='img'])",
 			"attributes": [
 				"aria-labelledby",
 				"aria-label",


### PR DESCRIPTION
Pour résoudre le problème soulevé dans l'issue #110, je propose d'ajouter explicitement les rôles ARIA `link` et `button` en plus des balises `<a>`et `<button>` au test 1.1.1 .

Cela pourrait être une bonne idée d'ajouter tous les rôles associés pour toutes les balises dans tous les tests, mais la modification serait assez massive (à voir s'il n'existe pas une meilleure solution pour une autre PR 😃)